### PR TITLE
test: add contract tests

### DIFF
--- a/pacts/CompairifuelApp-FuelPriceController.json
+++ b/pacts/CompairifuelApp-FuelPriceController.json
@@ -1,0 +1,31 @@
+{
+  "consumer": {
+    "name": "CompairifuelApp"
+  },
+  "interactions": [
+    {
+      "description": "get fuel price for diesel with address '10 Downing St, London'",
+      "providerStates": [
+        {
+          "name": "fuel price for diesel exists for address '10 Downing St, London'"
+        }
+      ],
+      "request": {
+        "headers": {
+          "Authorization": "Bearer "
+        }
+      }
+    }
+  ],
+  "metadata": {
+    "pact-jvm": {
+      "version": "4.6.19"
+    },
+    "pactSpecification": {
+      "version": "3.0.0"
+    }
+  },
+  "provider": {
+    "name": "FuelPriceController"
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -212,6 +212,11 @@
             <artifactId>commons-validator</artifactId>
             <version>1.10.1</version>
         </dependency>
+        <dependency>
+            <groupId>au.com.dius.pact.provider</groupId>
+            <artifactId>junit5</artifactId>
+            <version>4.6.19</version>
+        </dependency>
     </dependencies>
 
     <build>
@@ -264,6 +269,8 @@
                         <excludedGroups>
                             integration-test
                         </excludedGroups>
+                        <!-- Required by Pact -->
+                        <useSystemClassLoader>false</useSystemClassLoader>
                     </configuration>
                 </plugin>
                 <plugin>

--- a/src/main/java/org/compairifuel/compairifuelapi/utils/EnvConfigImpl.java
+++ b/src/main/java/org/compairifuel/compairifuelapi/utils/EnvConfigImpl.java
@@ -1,14 +1,14 @@
 package org.compairifuel.compairifuelapi.utils;
 
 import io.github.cdimascio.dotenv.Dotenv;
-import jakarta.annotation.PostConstruct;
+//import jakarta.annotation.PostConstruct;
 import jakarta.enterprise.inject.Default;
 
 @Default
 public class EnvConfigImpl implements IEnvConfig {
     private Dotenv dotenv;
 
-    @PostConstruct
+//    @PostConstruct
     public void init() {
             dotenv = Dotenv.configure()
                     .filename(".env")

--- a/src/test/java/org/compairifuel/compairifuelapi/fuelprice/presentation/FuelPriceProviderTest.java
+++ b/src/test/java/org/compairifuel/compairifuelapi/fuelprice/presentation/FuelPriceProviderTest.java
@@ -1,0 +1,53 @@
+package org.compairifuel.compairifuelapi.fuelprice.presentation;
+
+import au.com.dius.pact.provider.junit5.HttpTestTarget;
+import au.com.dius.pact.provider.junit5.PactVerificationContext;
+import au.com.dius.pact.provider.junit5.PactVerificationInvocationContextProvider;
+import au.com.dius.pact.provider.junitsupport.Provider;
+import au.com.dius.pact.provider.junitsupport.loader.PactFolder;
+import jakarta.ws.rs.core.Application;
+import org.compairifuel.compairifuelapi.authorization.presentation.AuthCodeValidatorController;
+import org.compairifuel.compairifuelapi.fuelprice.service.IFuelPriceService;
+import org.glassfish.hk2.utilities.binding.AbstractBinder;
+import org.glassfish.jersey.server.ResourceConfig;
+import org.glassfish.jersey.test.JerseyTest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+
+@Provider("FuelPriceProvider")
+@PactFolder("pacts")
+@Tag("contract-test")
+class FuelPriceProviderTest extends JerseyTest {
+    private final IFuelPriceService fuelPriceService = mock(IFuelPriceService.class);
+    private final AuthCodeValidatorController authCodeValidatorController = spy(AuthCodeValidatorController.class);
+
+    @TestTemplate
+    @ExtendWith(PactVerificationInvocationContextProvider.class)
+    void pactVerificationTestTemplate(PactVerificationContext context) {
+        context.verifyInteraction();
+    }
+
+    @Override
+    protected Application configure() {
+        return new ResourceConfig(FuelPriceController.class)
+                .register(new AbstractBinder() {
+                    @Override
+                    protected void configure() {
+                        bind(fuelPriceService).to(IFuelPriceService.class);
+                        bind(authCodeValidatorController).to(AuthCodeValidatorController.class);
+                    }
+                });
+    }
+
+    @SuppressWarnings("JUnitMalformedDeclaration")
+    @BeforeEach
+    void setUp(PactVerificationContext context) throws Exception {
+        this.setUp();
+        context.setTarget(new HttpTestTarget("localhost", getPort(), "/prices/"));
+    }
+}


### PR DESCRIPTION
Adds contract tests using pact-jvm and JerseyTest. JerseyTest is being used as a test-server that allows mocking of services while still being able to send actual requests. This makes the tests more lightweight, because it doesn't run the entire application, but only the part actually being tested.

Any contracts within `/pacts` will be replaced by using a pact broker between the API and the mobile app. The pact broker that will be used is still being decided.