### PR TITLE
chore(ci): improve ci with semver and releases

### DIFF
--- a/.github/workflows/semver_versioning_ci.yml
+++ b/.github/workflows/semver_versioning_ci.yml
@@ -1,0 +1,26 @@
+name: Semver Versioning CI
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  computing_version:
+    name: Compute Semver Version
+    uses: compairifuel/.github/.github/workflows/reusable-nextsemver.yml@main
+    with:
+      trunk-ref: "main"
+    permissions:
+      contents: read
+  add_release:
+    name: Add Version Tag & Release
+    needs: computing_version
+    uses: compairifuel/.github/.github/workflows/reusable-createrelease.yml@main
+    with:
+      tag-name: ${{ needs.computing_version.outputs.semver-tag }}
+    permissions:
+      contents: write
+    secrets: 
+      github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
The container registry step is not yet included. There is not enough material to fully utilize the container registry yet.
We dont have a registry yet, and also not enough dockerfiles, for this to be useful yet.

The plan to add this in the future can be solved by using something like this:

```
strategy:
	matrix:
		include:
			- image_name: "myImage"
			  dockerfile: "my/path/to/Dockerfile"
			  image_tag: "v1.4.5,latest"
			- image_name: "myImage2"
			  dockerfile: "my/path/to/Dockerfile"
			  build_args: "MYARG"
			  image_tag: "v2.0.6,latest"
```
Or something similar.