### PR TITLE
feat: new redirect uri validation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,6 +20,7 @@
         <jwt.version>0.12.6</jwt.version>
         <lombok.version>1.18.32</lombok.version>
         <sonar.organization>compairifuel</sonar.organization>
+        <jersey.version>3.0.4</jersey.version>
     </properties>
 
     <profiles>
@@ -100,6 +101,12 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-params</artifactId>
+            <version>${junit.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
             <version>${lombok.version}</version>
@@ -118,7 +125,7 @@
         <dependency>
             <groupId>org.glassfish.jersey.core</groupId>
             <artifactId>jersey-client</artifactId>
-            <version>3.0.4</version>
+            <version>${jersey.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -130,19 +137,49 @@
         <dependency>
             <groupId>org.glassfish.jersey.inject</groupId>
             <artifactId>jersey-hk2</artifactId>
-            <version>3.0.4</version>
+            <version>${jersey.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.glassfish.jersey.media</groupId>
             <artifactId>jersey-media-json-jackson</artifactId>
-            <version>3.0.4</version>
+            <version>${jersey.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.glassfish.jersey.media</groupId>
             <artifactId>jersey-media-json-processing</artifactId>
-            <version>3.0.4</version>
+            <version>${jersey.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish.jersey.test-framework</groupId>
+            <artifactId>jersey-test-framework-core</artifactId>
+            <version>${jersey.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish.jersey.test-framework.providers</groupId>
+            <artifactId>jersey-test-framework-provider-grizzly2</artifactId>
+            <version>${jersey.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish.jersey.core</groupId>
+            <artifactId>jersey-common</artifactId>
+            <version>${jersey.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish.jersey.core</groupId>
+            <artifactId>jersey-server</artifactId>
+            <version>${jersey.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish.jersey.ext</groupId>
+            <artifactId>jersey-bean-validation</artifactId>
+            <version>${jersey.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -164,6 +201,11 @@
             <groupId>commons-codec</groupId>
             <artifactId>commons-codec</artifactId>
             <version>1.13</version>
+        </dependency>
+        <dependency>
+            <groupId>commons-validator</groupId>
+            <artifactId>commons-validator</artifactId>
+            <version>1.10.1</version>
         </dependency>
     </dependencies>
 

--- a/src/main/java/org/compairifuel/compairifuelapi/authorization/presentation/AuthorizationController.java
+++ b/src/main/java/org/compairifuel/compairifuelapi/authorization/presentation/AuthorizationController.java
@@ -11,6 +11,7 @@ import lombok.extern.java.Log;
 import org.compairifuel.compairifuelapi.authorization.service.IAuthorizationService;
 import org.compairifuel.compairifuelapi.authorization.service.domain.AccessTokenDomain;
 import org.compairifuel.compairifuelapi.utils.presentation.CacheControlDirectives;
+import org.compairifuel.compairifuelapi.utils.presentation.validation.RedirectURI;
 
 import java.net.URI;
 
@@ -35,7 +36,7 @@ public class AuthorizationController {
     @GET
     @Path("")
     @Produces(MediaType.APPLICATION_JSON)
-    public Response getAuthorizationCode(@QueryParam("response_type") @Pattern(regexp = "(code)", message = "response_type must be set to “code”.") String responseType, @QueryParam("client_id") String clientId, @QueryParam("redirect_uri") @Pattern(regexp = "^([a-zA-Z]{2,}://[\\w-]+(\\.[\\w-]+)?([\\w.,@?^=%&:/~+#-]*[\\w@?^=%&/~+#-])?)$", message = "redirect_uri must be a valid uri") @NotBlank(message = "redirect_uri cannot be blank!") String redirectUri, @QueryParam("code_challenge") @NotBlank(message = "code_challenge cannot be blank!") String codeChallenge, @QueryParam("state") @NotBlank(message = "state cannot be blank!") String state) {
+    public Response getAuthorizationCode(@QueryParam("response_type") @Pattern(regexp = "(code)", message = "response_type must be set to “code”.") String responseType, @QueryParam("client_id") String clientId, @QueryParam("redirect_uri") @NotBlank(message = "redirect_uri cannot be blank!") @RedirectURI(message = "redirect_uri must be a valid uri.") String redirectUri, @QueryParam("code_challenge") @NotBlank(message = "code_challenge cannot be blank!") String codeChallenge, @QueryParam("state") @NotBlank(message = "state cannot be blank!") String state) {
         URI redirectToURI = authorizationService.getAuthorizationCode(responseType, clientId, redirectUri, codeChallenge, state);
         return Response.seeOther(redirectToURI).header(HttpHeaders.CACHE_CONTROL, CacheControlDirectives.NO_STORE).build();
     }
@@ -54,7 +55,7 @@ public class AuthorizationController {
     @Path("/token")
     @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
     @Produces(MediaType.APPLICATION_JSON)
-    public Response getAccessToken(@FormParam("grant_type") @Pattern(regexp = "authorization_code", message = "grant_type must be set to “authorization_code”.") String grantType, @FormParam("code") @NotBlank(message = "code cannot be blank!") String code, @FormParam("redirect_uri") @Pattern(regexp = "^([a-zA-Z]{2,}://[\\w-]+(\\.[\\w-]+)?([\\w.,@?^=%&:/~+#-]*[\\w@?^=%&/~+#-])?)$", message = "redirect_uri must be a valid uri") @NotBlank(message = "redirect_uri cannot be blank!") String redirectUri, @FormParam("client_id") String clientId, @FormParam("code_verifier") @NotBlank(message = "code_verifier cannot be blank!") String codeVerifier) {
+    public Response getAccessToken(@FormParam("grant_type") @Pattern(regexp = "authorization_code", message = "grant_type must be set to “authorization_code”.") String grantType, @FormParam("code") @NotBlank(message = "code cannot be blank!") String code, @FormParam("redirect_uri") @NotBlank(message = "redirect_uri cannot be blank!") @RedirectURI(message = "redirect_uri must be a valid uri.") String redirectUri, @FormParam("client_id") String clientId, @FormParam("code_verifier") @NotBlank(message = "code_verifier cannot be blank!") String codeVerifier) {
         AccessTokenDomain accessTokenDomain = authorizationService.getAccessToken(grantType, code, redirectUri, clientId, codeVerifier);
 
         AccessTokenResponseDTO response = buildAccessTokenResponseDTO(accessTokenDomain);

--- a/src/main/java/org/compairifuel/compairifuelapi/utils/presentation/validation/RedirectURI.java
+++ b/src/main/java/org/compairifuel/compairifuelapi/utils/presentation/validation/RedirectURI.java
@@ -1,0 +1,18 @@
+package org.compairifuel.compairifuelapi.utils.presentation.validation;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
+import java.lang.annotation.*;
+
+@Documented
+@Target({ ElementType.PARAMETER })
+@Retention(RetentionPolicy.RUNTIME)
+@Constraint(validatedBy = {RedirectURIValidator.class})
+public @interface RedirectURI {
+    String message() default "Redirect URI must be a valid uri";
+
+    Class<?>[] groups() default {};
+
+    Class<? extends Payload>[] payload() default {};
+}

--- a/src/main/java/org/compairifuel/compairifuelapi/utils/presentation/validation/RedirectURIValidator.java
+++ b/src/main/java/org/compairifuel/compairifuelapi/utils/presentation/validation/RedirectURIValidator.java
@@ -1,0 +1,20 @@
+package org.compairifuel.compairifuelapi.utils.presentation.validation;
+
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+import org.apache.commons.validator.routines.UrlValidator;
+
+import java.net.URI;
+
+public class RedirectURIValidator implements ConstraintValidator<RedirectURI, String> {
+    @Override
+    public boolean isValid(String value, ConstraintValidatorContext context) {
+        UrlValidator validator = new UrlValidator(UrlValidator.ALLOW_ALL_SCHEMES | UrlValidator.NO_FRAGMENTS | UrlValidator.ALLOW_LOCAL_URLS);
+        if (!validator.isValid(value)) {
+            return false;
+        }
+
+        URI uri = URI.create(value);
+        return uri.getUserInfo() == null;
+    }
+}

--- a/src/test/java/org/compairifuel/compairifuelapi/authorization/presentation/AuthorizationControllerAPIFixtures.java
+++ b/src/test/java/org/compairifuel/compairifuelapi/authorization/presentation/AuthorizationControllerAPIFixtures.java
@@ -1,0 +1,179 @@
+package org.compairifuel.compairifuelapi.authorization.presentation;
+
+import jakarta.ws.rs.core.UriBuilder;
+import org.junit.jupiter.params.provider.Arguments;
+
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Stream;
+
+@SuppressWarnings("unused") // Used by parameterized tests in AuthorizationControllerAPITest
+class AuthorizationControllerAPIFixtures {
+    static Stream<Arguments> provideValidRedirectURIGetAuthorizationCodeParameters() {
+        return generateValidRedirectURIs().stream()
+                .map(uri -> Arguments.of(
+                        "code",
+                        "6779ef20e75817b79602",
+                        uri.toString(),
+                        "pjGXfmpx1LUHqbxEB2KhEp5QXEA0XA5imOTeefSmmzI",
+                        "%7B%7D",
+                        UriBuilder.fromUri(uri)
+                            .queryParam("state", "%7B%7D")
+                            .queryParam("code", "123")
+                            .build()
+                ));
+    }
+
+    static Stream<Arguments> provideValidClientIdGetAuthorizationCodeParameters() {
+        List<String> clientIds = List.of(
+                "ZYDPLLBWSK3MVQJSIYHB1OR2JXCY0X2C5UJ2QAR2MAAIT5Q",
+                "6779ef20e75817b79602",
+                "292085223830.apps.example.com",
+                "f2a1ed52710d4533bde25be6da03b6e3",
+                "269d98e4922fb3895e9ae2108cbb5064",
+                "00000000400ECB04",
+                "0oa2hl2inow5Uqc6c357"
+        );
+        return clientIds.stream()
+                .map(clientId -> Arguments.of(
+                        "code",
+                        clientId,
+                        "http://localhost:8080",
+                        "pjGXfmpx1LUHqbxEB2KhEp5QXEA0XA5imOTeefSmmzI",
+                        "%7B%7D",
+                        "http://localhost:8080?state=%7B%7D&code=123"
+                ));
+    }
+
+    static Stream<Arguments> provideValidCodeChallengeGetAuthorizationCodeParameters() {
+        List<String> codeChallenges = List.of(
+            "pjGXfmpx1LUHqbxEB2KhEp5QXEA0XA5imOTeefSmmzI",
+            "NDc0ZWQ5M2MwYTgwZGVhZGU4NWU4ODgwNDNhOThjYmQwNTk1ZjA3YzdlMjlhZTIwYTQwMDg3MDFkZDQ2YjNhZQ",
+            "YThkODY3OWM4Y2U2ZDAxMTZmNGZkYjAyZjUzMjJkMjkyNjg3NzBhMjhmMWNmMzUyYTY1NzJhNDUxMjU5ZTMxMQ"
+        );
+        return codeChallenges.stream()
+                .map(codeChallenge -> Arguments.of(
+                        "code",
+                        "6779ef20e75817b79602",
+                        "http://localhost:8080",
+                        codeChallenge,
+                        "%7B%7D",
+                        "http://localhost:8080?state=%7B%7D&code=123"
+                ));
+    }
+
+    static Stream<Arguments> provideInvalidRedirectURIGetAuthorizationCodeParameters() {
+        return generateInvalidRedirectURIs().stream()
+                .map(uri -> Arguments.of(
+                        "code",
+                        "6779ef20e75817b79602",
+                        uri,
+                        "pjGXfmpx1LUHqbxEB2KhEp5QXEA0XA5imOTeefSmmzI",
+                        "%7B%7D"
+                ));
+    }
+
+    static Stream<Arguments> provideValidRedirectURIGetAccessTokenParameters() {
+        return generateValidRedirectURIs().stream()
+                .map(uri -> Arguments.of(
+                        "authorization_code",
+                        "6779ef20e75817b79602",
+                        uri.toString(),
+                        "6779ef20e75817b79602",
+                        "S256CodeVerifierExample123!"
+                ));
+    }
+
+    static Stream<Arguments> provideInvalidRedirectURIGetAccessTokenParameters() {
+        return generateInvalidRedirectURIs().stream()
+                .map(uri -> Arguments.of(
+                        "authorization_code",
+                        "6779ef20e75817b79602",
+                        uri,
+                        "6779ef20e75817b79602",
+                        "S256CodeVerifierExample123!"
+                ));
+    }
+
+    private static List<URI> generateValidRedirectURIs() {
+        UriBuilder customSchemeBuilder = UriBuilder.newInstance()
+                .scheme("myapp");
+        UriBuilder exampleComBuilder = UriBuilder.newInstance()
+                .host("example.com");
+        List<UriBuilder> baseBuilders = List.of(
+                customSchemeBuilder.clone()
+                        .host("oauth"),
+                exampleComBuilder.clone()
+                        .scheme("http"),
+                exampleComBuilder.clone()
+                        .scheme("https"),
+                UriBuilder.newInstance()
+                        .scheme("http")
+                        .host("localhost"),
+                UriBuilder.newInstance()
+                        .scheme("http")
+                        .host("sub.example.com"),
+                UriBuilder.newInstance()
+                        .scheme("https")
+                        .host("sub.example.com")
+        );
+
+        return baseBuilders.stream()
+                .flatMap(uri -> Stream.of(
+                        uri.clone(),
+                        uri.clone().port(8080)
+                ))
+                .flatMap(uri -> Stream.of(
+                        uri.clone(),
+                        uri.clone().path("callback"),
+                        uri.clone().path("oauth/callback"),
+                        uri.clone().path("oauth/callback.php")
+                ))
+                .flatMap(uri -> Stream.of(
+                        uri.clone(),
+                        uri.clone().queryParam("param", "value"),
+                        uri.clone().queryParam("a", 1).queryParam("b", 3),
+                        uri.clone()
+                                .queryParam("a")
+                                .queryParam("b", 3)
+                                .queryParam("c", true)
+                                .queryParam("d", "string")
+                                .queryParam("e", 3, true, 5, false, "value")
+                ))
+                .map(UriBuilder::build)
+                .toList();
+    }
+
+    private static List<String> generateInvalidRedirectURIs() {
+        List<String> uris = new ArrayList<>(List.of(
+                "invalid",
+                "",
+                " ",
+                "\t",
+                " \t ",
+                "http:/example.com",
+                "http//example.com",
+                "://example.com",
+                "http://",
+                "http://?",
+                "http://#",
+                "http://example .com",
+                "http://example.com/pa th",
+                "http://example.com/pa<th",
+                "https://example.com/oauth/callback\n",
+                "https://example.com/oauth/callback\r\n",
+                "https://example.com/oauth/callback\t",
+                "https://example.com/oauth/callback#fragment", // Fragments are not allowed in redirect URIs
+                "https://user:password@localhost:8080/callback", // User info is not allowed in redirect URIs
+                "http://localhost:8080/\u0000", // Null character
+                "http://local host:8080/callback",
+                "http://例子.测试/callback",
+                "http://localhost:6060/oauth//callback",
+                "https://thishostnameiswaytoolongtobevalidbecauseithasmorethanthesixtythreecharacterlimitsetbytherfc.org/callback",
+                "https://this.url.is.too.long.because.it.has.more.than.two.hundered.fifty.three.characters." + "a".repeat(200) + ".com/callback"
+        ));
+        uris.add(null);
+        return uris;
+    }
+}

--- a/src/test/java/org/compairifuel/compairifuelapi/authorization/presentation/AuthorizationControllerAPITest.java
+++ b/src/test/java/org/compairifuel/compairifuelapi/authorization/presentation/AuthorizationControllerAPITest.java
@@ -1,0 +1,138 @@
+package org.compairifuel.compairifuelapi.authorization.presentation;
+
+import jakarta.ws.rs.client.Entity;
+import jakarta.ws.rs.core.*;
+import org.compairifuel.compairifuelapi.authorization.service.IAuthorizationService;
+import org.compairifuel.compairifuelapi.authorization.service.domain.AccessTokenDomain;
+import org.compairifuel.compairifuelapi.utils.presentation.CacheControlDirectives;
+import org.glassfish.hk2.utilities.binding.AbstractBinder;
+import org.glassfish.jersey.client.ClientConfig;
+import org.glassfish.jersey.client.ClientProperties;
+import org.glassfish.jersey.server.ResourceConfig;
+import org.glassfish.jersey.test.JerseyTest;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.net.URI;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@Tag("api-test")
+class AuthorizationControllerAPITest extends JerseyTest {
+    IAuthorizationService authorizationService = mock(IAuthorizationService.class);
+
+    @Override
+    protected Application configure() {
+        return new ResourceConfig(AuthorizationController.class)
+                .register(new AbstractBinder() {
+                    @Override
+                    protected void configure() {
+                        bind(authorizationService).to(IAuthorizationService.class);
+                    }
+                });
+    }
+
+    @Override
+    protected void configureClient(ClientConfig config) {
+        config.property(ClientProperties.FOLLOW_REDIRECTS, false);
+    }
+
+    @DisplayName("GIVEN valid parameters WHEN getAuthorizationCode is called THEN it validates parameters without errors")
+    @ParameterizedTest(name = "parameters: responseType={0}, clientId={1}, redirectUri={2}, codeChallenge={3}, state={4}, redirectToUri={5}")
+    @MethodSource({
+            "org.compairifuel.compairifuelapi.authorization.presentation.AuthorizationControllerAPIFixtures#provideValidRedirectURIGetAuthorizationCodeParameters",
+            "org.compairifuel.compairifuelapi.authorization.presentation.AuthorizationControllerAPIFixtures#provideValidClientIdGetAuthorizationCodeParameters",
+            "org.compairifuel.compairifuelapi.authorization.presentation.AuthorizationControllerAPIFixtures#provideValidCodeChallengeGetAuthorizationCodeParameters"
+    })
+    void testGetAuthorizationCodeValidatesParametersWithoutErrors(String responseType, String clientId, String redirectUri, String codeChallenge, String state, URI redirectToURI) {
+        when(authorizationService.getAuthorizationCode(responseType, clientId, redirectUri, codeChallenge, "{}"))
+                .thenReturn(redirectToURI);
+
+        Response response = target("/oauth")
+                .queryParam("response_type", responseType)
+                .queryParam("client_id", clientId)
+                .queryParam("redirect_uri", redirectUri)
+                .queryParam("code_challenge", codeChallenge)
+                .queryParam("state", state)
+                .request(MediaType.APPLICATION_JSON)
+                .get();
+
+        assertEquals(Response.Status.SEE_OTHER.getStatusCode(), response.getStatus(), "Response code should be 303 See Other");
+        assertEquals(redirectToURI, response.getLocation());
+        assertTrue(response.getHeaders().containsKey(HttpHeaders.CACHE_CONTROL), "Response should contain Cache-Control header");
+        assertEquals(1, response.getHeaders().get(HttpHeaders.CACHE_CONTROL).size(), "Cache-Control header should have one value");
+        assertEquals(CacheControlDirectives.NO_STORE, response.getHeaders().get(HttpHeaders.CACHE_CONTROL).get(0));
+    }
+
+    @DisplayName("GIVEN invalid parameters WHEN getAuthorizationCode is called THEN response is 400")
+    @ParameterizedTest(name = "parameters: responseType={0}, clientId={1}, redirectUri={2}, codeChallenge={3}, state={4}")
+    @MethodSource("org.compairifuel.compairifuelapi.authorization.presentation.AuthorizationControllerAPIFixtures#provideInvalidRedirectURIGetAuthorizationCodeParameters")
+    void testGetAuthorizationCodeValidatesParametersWithErrors(String responseType, String clientId, String redirectUri, String codeChallenge, String state) {
+        when(authorizationService.getAuthorizationCode(responseType, clientId, redirectUri, codeChallenge, state))
+                .thenReturn(URI.create("http://localhost:8080?state=%7B&7D&code=123"));
+
+        Response response = target("/oauth")
+                .queryParam("response_type", responseType)
+                .queryParam("client_id", clientId)
+                .queryParam("redirect_uri", redirectUri)
+                .queryParam("code_challenge", codeChallenge)
+                .queryParam("state", state)
+                .request(MediaType.APPLICATION_JSON)
+                .get();
+
+        assertEquals(Response.Status.BAD_REQUEST.getStatusCode(), response.getStatus());
+    }
+
+    @DisplayName("GIVEN valid parameters WHEN getAccessToken is called THEN it validates parameters without errors")
+    @ParameterizedTest(name = "parameters: grantType={0}, code={1}, redirectUri={2}, clientId={3}, codeVerifier={4}")
+    @MethodSource("org.compairifuel.compairifuelapi.authorization.presentation.AuthorizationControllerAPIFixtures#provideValidRedirectURIGetAccessTokenParameters")
+    void testGetAccessTokenValidatesParametersWithoutErrors(String grantType, String code, String redirectUri, String clientId, String codeVerifier) {
+        when(authorizationService.getAccessToken(grantType, code, redirectUri, clientId, codeVerifier))
+                .thenReturn(new AccessTokenDomain());
+
+        try (
+            Response response = target("/oauth/token")
+                .request(MediaType.APPLICATION_JSON)
+                .post(Entity.form(
+                        new Form()
+                                .param("grant_type", grantType)
+                                .param("code", code)
+                                .param("redirect_uri", redirectUri)
+                                .param("client_id", clientId)
+                                .param("code_verifier", codeVerifier)
+                ))
+        ) {
+            assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
+            assertTrue(response.getHeaders().containsKey(HttpHeaders.CACHE_CONTROL), "Response should contain Cache-Control header");
+            assertEquals(1, response.getHeaders().get(HttpHeaders.CACHE_CONTROL).size(), "Cache-Control header should have one value");
+            assertEquals(CacheControlDirectives.NO_STORE, response.getHeaders().get(HttpHeaders.CACHE_CONTROL).get(0));
+        }
+    }
+
+    @DisplayName("GIVEN invalid parameters WHEN getAccessToken is called THEN response is 400")
+    @ParameterizedTest(name = "parameters: grantType={0}, code={1}, redirectUri={2}, clientId={3}, codeVerifier={4}")
+    @MethodSource("org.compairifuel.compairifuelapi.authorization.presentation.AuthorizationControllerAPIFixtures#provideInvalidRedirectURIGetAccessTokenParameters")
+    void testGetAccessTokenValidatesParametersWithErrors(String grantType, String code, String redirectUri, String clientId, String codeVerifier) {
+        when(authorizationService.getAccessToken(grantType, code, redirectUri, clientId, codeVerifier))
+                .thenReturn(new AccessTokenDomain());
+
+        try (
+            Response response = target("/oauth/token")
+                    .request(MediaType.APPLICATION_JSON)
+                    .post(Entity.form(
+                            new Form()
+                                    .param("grant_type", grantType)
+                                    .param("code", code)
+                                    .param("redirect_uri", redirectUri)
+                                    .param("client_id", clientId)
+                                    .param("code_verifier", codeVerifier
+                    )))
+        ) {
+            assertEquals(Response.Status.BAD_REQUEST.getStatusCode(), response.getStatus());
+        }
+    }
+}


### PR DESCRIPTION
Adds a new `@RedirectURI` annotation that can be used in controllers to validate whether a parameter is a valid redirect uri. This annotation has a validator (`RedirectURIValidator`), which uses a combination of commons-validator and custom uri checks to determine if the uri is a valid redirect uri.

A new test class has been added that uses API testing to determine whether this the `AuthorizationController` has the correct validation for redirect uris. This test class uses JerseyTest to start up a local server containing the controller and mocked instances of its services. 

The reason an API test is used instead of a normal unit test is because Jakarta validation constraints like `@NotBlank` can't be tested using normal unit-test methods. These annotations get processed before the controller methods are called. This means the method's parameter constraints get validated before calling the methods.